### PR TITLE
feat: 게시글 작성, 댓글, 대댓글 작성 기능 구현

### DIFF
--- a/src/main/java/apptive/devlog/post/Post.java
+++ b/src/main/java/apptive/devlog/post/Post.java
@@ -1,0 +1,51 @@
+package apptive.devlog.post;
+
+import apptive.devlog.post.comment.Comment;
+import apptive.devlog.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_uuid", nullable = false)
+    private User author;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isDeleted = false;
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Comment> comments;
+}

--- a/src/main/java/apptive/devlog/post/PostController.java
+++ b/src/main/java/apptive/devlog/post/PostController.java
@@ -1,0 +1,82 @@
+package apptive.devlog.post;
+
+import apptive.devlog.common.CommonResponse;
+import apptive.devlog.post.dto.PostCreateRequest;
+import apptive.devlog.post.dto.PostData;
+import apptive.devlog.post.dto.PostListItem;
+import apptive.devlog.post.dto.PostUpdateRequest;
+import apptive.devlog.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/post")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping
+    @Operation(summary = "게시글 업로드", description = "게시글 업로드")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "업로드 성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    public ResponseEntity<?> createPost(
+            @RequestBody @Valid PostCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        postService.createPost(request, userDetails.getUser());
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "게시글이 업로드 되었습니다.");
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "게시글 가져오기", description = "게시글 가져오기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    public ResponseEntity<?> getPost(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PostData postData = postService.getPost(id, userDetails.getUser());
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "성공", postData);
+    }
+
+    @GetMapping
+    @Operation(summary = "게시글 목록 가져오기", description = "게시글 목록 가져오기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    public ResponseEntity<?> getPosts() {
+        List<PostListItem> posts = postService.getPosts();
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "성공", posts);
+    }
+
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "게시글 수정", description = "게시글 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    public ResponseEntity<?> updatePost(
+            @PathVariable Long id,
+            @RequestBody @Valid PostUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        postService.updatePost(id, request, userDetails.getUser());
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "게시글이 수정되었습니다.");
+    }
+
+    @DeleteMapping("/{postId}")
+    @Operation(summary = "게시글 삭제", description = "게시글 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    public ResponseEntity<?> deletePost(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        postService.deletePost(postId, userDetails.getUser());
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "게시글이 삭제되었습니다.");
+    }
+}

--- a/src/main/java/apptive/devlog/post/PostRepository.java
+++ b/src/main/java/apptive/devlog/post/PostRepository.java
@@ -1,0 +1,11 @@
+package apptive.devlog.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByIdAndIsDeletedFalse(Long id);
+    List<Post> findByIsDeletedFalseOrderByCreatedAtAsc();
+}

--- a/src/main/java/apptive/devlog/post/PostService.java
+++ b/src/main/java/apptive/devlog/post/PostService.java
@@ -1,0 +1,74 @@
+package apptive.devlog.post;
+
+import apptive.devlog.post.dto.PostCreateRequest;
+import apptive.devlog.post.dto.PostData;
+import apptive.devlog.post.dto.PostListItem;
+import apptive.devlog.post.dto.PostUpdateRequest;
+import apptive.devlog.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostService {
+    private final PostRepository postRepository;
+
+    public void createPost(PostCreateRequest request, User user) {
+        postRepository.save(
+                Post.builder()
+                        .title(request.title())
+                        .content(request.content())
+                        .author(user)
+                        .build());
+    }
+
+    public PostData getPost(Long id, User user) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+
+        return PostData.builder()
+                .title(post.getTitle()).content(post.getContent())
+                .authorNickname(post.getAuthor().getNickname())
+                .createdAt(post.getCreatedAt()).updatedAt(post.getUpdatedAt())
+                .isPostOwner(post.getAuthor().equals(user))
+                .build();
+    }
+
+    public List<PostListItem> getPosts() {
+        return postRepository.findByIsDeletedFalseOrderByCreatedAtAsc().stream()
+                .map(post -> PostListItem.builder()
+                        .id(post.getId())
+                        .title(post.getTitle())
+                        .authorNickname(post.getAuthor().getNickname())
+                        .createdAt(post.getCreatedAt())
+                        .build())
+                .toList();
+    }
+
+    public void updatePost(Long id, PostUpdateRequest request, User user) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+        if (!post.getAuthor().equals(user))
+            throw new IllegalArgumentException("게시글 작성자가 아닙니다.");
+
+        if (request.title() != null)
+            post.setTitle(request.title());
+        if (request.content() != null)
+            post.setContent(request.content());
+        postRepository.save(post);
+    }
+
+    public void deletePost(Long id, User user) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+        if (!post.getAuthor().equals(user))
+            throw new IllegalArgumentException("게시글 작성자가 아닙니다.");
+
+        post.setIsDeleted(true);
+        postRepository.save(post);
+    }
+}

--- a/src/main/java/apptive/devlog/post/comment/Comment.java
+++ b/src/main/java/apptive/devlog/post/comment/Comment.java
@@ -1,0 +1,58 @@
+package apptive.devlog.post.comment;
+
+import apptive.devlog.post.Post;
+import apptive.devlog.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+    @Id
+    @GeneratedValue
+    @Column(nullable = false, updatable = false)
+    private UUID uuid;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_uuid", nullable = false)
+    private User author;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_uuid")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Comment> replies;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/apptive/devlog/post/comment/CommentController.java
+++ b/src/main/java/apptive/devlog/post/comment/CommentController.java
@@ -1,0 +1,78 @@
+package apptive.devlog.post.comment;
+
+import apptive.devlog.common.CommonResponse;
+import apptive.devlog.post.comment.dto.CommentCreateRequest;
+import apptive.devlog.post.comment.dto.CommentData;
+import apptive.devlog.post.comment.dto.CommentUpdateRequest;
+import apptive.devlog.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/post/{postId}/comment")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 업로드", description = "댓글 업로드")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "업로드 성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    @PostMapping
+    public ResponseEntity<?> createComment(
+            @PathVariable Long postId,
+            @RequestBody @Valid CommentCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        commentService.createComment(postId, request, userDetails.getUser());
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "댓글이 등록되었습니다.");
+    }
+
+    @Operation(summary = "댓글 목록 조회", description = "댓글 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    @GetMapping
+    public ResponseEntity<?> getComments(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        List<CommentData> data = commentService.getComments(postId, userDetails.getUser());
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "성공", data);
+    }
+
+    @Operation(summary = "댓글 수정", description = "댓글 수정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<?> updateComment(
+            @PathVariable UUID commentId,
+            @RequestBody @Valid CommentUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        commentService.updateComment(commentId, request, userDetails.getUser());
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "댓글이 수정되었습니다.");
+    }
+
+    @Operation(summary = "댓글 삭제", description = "댓글 삭제")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CommonResponse.class)))})
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> deleteComment(
+            @PathVariable UUID commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        commentService.deleteComment(commentId, userDetails.getUser());
+        return CommonResponse.buildResponseEntity(HttpStatus.OK, "댓글이 삭제되었습니다.");
+    }
+}

--- a/src/main/java/apptive/devlog/post/comment/CommentRepository.java
+++ b/src/main/java/apptive/devlog/post/comment/CommentRepository.java
@@ -1,0 +1,14 @@
+package apptive.devlog.post.comment;
+
+import apptive.devlog.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CommentRepository extends JpaRepository<Comment, UUID> {
+    Optional<Comment> findByUuidAndIsDeleted(UUID uuid, boolean deleted);
+    List<Comment> findByPostOrderByCreatedAtAsc(Post post);
+}
+

--- a/src/main/java/apptive/devlog/post/comment/CommentService.java
+++ b/src/main/java/apptive/devlog/post/comment/CommentService.java
@@ -1,0 +1,94 @@
+package apptive.devlog.post.comment;
+
+import apptive.devlog.post.Post;
+import apptive.devlog.post.PostRepository;
+import apptive.devlog.post.comment.dto.CommentCreateRequest;
+import apptive.devlog.post.comment.dto.CommentData;
+import apptive.devlog.post.comment.dto.CommentUpdateRequest;
+import apptive.devlog.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    public void createComment(Long postId, CommentCreateRequest request, User user) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        Comment parent = (request.parentId() != null)
+                ? commentRepository.findByUuidAndIsDeleted(request.parentId(), false)
+                .orElseThrow(() -> new IllegalArgumentException("상위 댓글이 없습니다."))
+                : null;
+
+        Comment comment = Comment.builder()
+                .content(request.content())
+                .post(post)
+                .parent(parent)
+                .author(user)
+                .build();
+
+        commentRepository.save(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentData> getComments(Long postId, User user) {
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        return commentRepository.findByPostOrderByCreatedAtAsc(post).stream()
+                .filter(comment -> comment.getParent() == null && (!comment.isDeleted() || !comment.getReplies().isEmpty()))
+                .map(comment -> toDto(comment, user))
+                .toList();
+    }
+
+    private CommentData toDto(Comment comment, User user) {
+        CommentData.CommentDataBuilder commentDataBuilder = CommentData.builder()
+                .uuid(comment.getUuid())
+                .content(comment.isDeleted() ? "(삭제된 댓글)" : comment.getContent())
+                .isDeleted(comment.isDeleted())
+                .isCommentOwner(comment.getAuthor().equals(user))
+                .replies(comment.getReplies().stream()
+                        .filter(reply -> !reply.isDeleted() || !reply.getReplies().isEmpty())
+                        .map(reply -> toDto(reply, user))
+                        .toList());
+
+        if (!comment.isDeleted()) {
+            commentDataBuilder = commentDataBuilder.authorNickname(comment.getAuthor().getNickname())
+                    .createdAt(comment.getCreatedAt());
+        }
+
+        return commentDataBuilder.build();
+    }
+
+    public void updateComment(UUID commentId,
+                              CommentUpdateRequest req,
+                              User user) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다."));
+
+        if (!comment.getAuthor().equals(user))
+            throw new IllegalArgumentException("권한이 없습니다.");
+
+        comment.setContent(req.content());
+    }
+
+    public void deleteComment(UUID commentId, User user) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        if (!comment.getAuthor().equals(user))
+            throw new IllegalArgumentException("권한이 없습니다.");
+
+        comment.setDeleted(true);
+    }
+
+}

--- a/src/main/java/apptive/devlog/post/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/apptive/devlog/post/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,11 @@
+package apptive.devlog.post.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public record CommentCreateRequest(
+        @NotBlank(message = "내용은 필수 입력값입니다.")
+        String content,
+        UUID parentId
+) {}

--- a/src/main/java/apptive/devlog/post/comment/dto/CommentData.java
+++ b/src/main/java/apptive/devlog/post/comment/dto/CommentData.java
@@ -1,0 +1,18 @@
+package apptive.devlog.post.comment.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Builder
+public record CommentData(
+        UUID uuid,
+        String content,
+        String authorNickname,
+        Boolean isDeleted,
+        Boolean isCommentOwner,
+        LocalDateTime createdAt,
+        List<CommentData> replies
+) {}

--- a/src/main/java/apptive/devlog/post/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/apptive/devlog/post/comment/dto/CommentUpdateRequest.java
@@ -1,0 +1,8 @@
+package apptive.devlog.post.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentUpdateRequest(
+        @NotBlank(message = "내용은 필수 입력값입니다.")
+        String content
+) {}

--- a/src/main/java/apptive/devlog/post/dto/PostCreateRequest.java
+++ b/src/main/java/apptive/devlog/post/dto/PostCreateRequest.java
@@ -1,0 +1,11 @@
+package apptive.devlog.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PostCreateRequest(
+        @NotBlank(message = "제목은 필수 입력값입니다.")
+        String title,
+
+        @NotBlank(message = "내용은 필수 입력값입니다.")
+        String content
+) { }

--- a/src/main/java/apptive/devlog/post/dto/PostData.java
+++ b/src/main/java/apptive/devlog/post/dto/PostData.java
@@ -1,0 +1,16 @@
+package apptive.devlog.post.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PostData(
+        String title,
+        String content,
+        String authorNickname,
+        Boolean isPostOwner,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/apptive/devlog/post/dto/PostListItem.java
+++ b/src/main/java/apptive/devlog/post/dto/PostListItem.java
@@ -1,0 +1,14 @@
+package apptive.devlog.post.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PostListItem(
+        Long id,
+        String title,
+        String authorNickname,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/apptive/devlog/post/dto/PostUpdateRequest.java
+++ b/src/main/java/apptive/devlog/post/dto/PostUpdateRequest.java
@@ -1,0 +1,6 @@
+package apptive.devlog.post.dto;
+
+public record PostUpdateRequest(
+        String title,
+        String content
+) { }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 #validate
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+spring.jpa.open-in-view=false
 
 spring.datasource.hikari.maximum-pool-size=20
 spring.datasource.hikari.minimum-idle=5


### PR DESCRIPTION
# 변경점 👍
9개 엔드포인트 구현
- 게시글 목록 가져오기 `GET /post`
- 게시글 업로드 `POST /post`
- 게시글 가져오기 `GET /post/{id}`
- 게시글 수정 `PATCH /post/{id}`
- 게시글 삭제 `DELETE /post/{postId}`
- 댓글 목록 조회 `GET /post/{postId}/comment`
- 댓글 업로드 `POST /post/{postId}/comment`
- 댓글 삭제 `DELETE /post/{postId}/comment/{commentId}`
- 댓글 수정 `PATCH /post/{postId}/comment/{commentId}`

상세 내용 : [https://devlog.jun0.dev/swagger-ui/index.html](https://devlog.jun0.dev/swagger-ui/index.html)

 
# 스크린샷 🖼
<img width="727" alt="image" src="https://github.com/user-attachments/assets/7a8e183d-e6b6-438b-8475-7592d035461c" />
 
# 비고 ✏
 - N+1 문제 해결 필요
 - 아직 특정 예외(사용자가 탈퇴할 경우 기존 게시글, 댓글의 처리)에 대해 다 구현하지 못해 수정 필요..

